### PR TITLE
Campaign Stats Quick Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2891,8 +2891,8 @@
       }
     },
     "adex-translations": {
-      "version": "git+https://git@github.com/AdExBlockchain/adex-translations.git#a79c0d561553afab2bb18c3608b68e790751d424",
-      "from": "git+https://git@github.com/AdExBlockchain/adex-translations.git#a79c0d561553afab2bb18c3608b68e790751d424"
+      "version": "git+https://git@github.com/AdExBlockchain/adex-translations.git#57fdb9c9a634cc5ab4f540327f649a398a616303",
+      "from": "git+https://git@github.com/AdExBlockchain/adex-translations.git#57fdb9c9a634cc5ab4f540327f649a398a616303"
     },
     "ajv": {
       "version": "6.6.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "adex-constants": "1.0.10",
     "adex-models": "git+https://git@github.com/AdExBlockchain/adex-models.git#6163083888552241d11e7a00217a4225a76df7a2",
     "adex-protocol-eth": "4.1.3",
-    "adex-translations": "git+https://git@github.com/AdExBlockchain/adex-translations.git#a79c0d561553afab2bb18c3608b68e790751d424",
+    "adex-translations": "git+https://git@github.com/AdExBlockchain/adex-translations.git#57fdb9c9a634cc5ab4f540327f649a398a616303",
     "autoprefixer": "7.1.6",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",

--- a/src/components/dashboard/containers/Tables/commonFilters.js
+++ b/src/components/dashboard/containers/Tables/commonFilters.js
@@ -19,12 +19,9 @@ export const sliderFilterOptions = ({ initial, filterTitle, stepSetting }) => {
 		filterOptions: {
 			names: [],
 			logic: (rowNumber, filters) => {
-				const formated = rowNumber
+				const formated = Number(rowNumber.toString().replace(/[^0-9.]/g, ''))
 				if (filters.length > 0) {
-					return (
-						Number(formatNumberWithoutCommas(formated)) < filters[0] ||
-						Number(formatNumberWithoutCommas(formated)) > filters[1]
-					)
+					return formated < filters[0] || formated > filters[1]
 				}
 				return false
 			},

--- a/src/selectors/tablesDataSelectors.js
+++ b/src/selectors/tablesDataSelectors.js
@@ -153,9 +153,12 @@ export const selectCampaignStatsMaxValues = createSelector(
 				newResult.maxClicks = Math.max(current.clicks, newResult.maxClicks)
 				newResult.maxImpressions = Math.max(
 					current.impressions,
-					newResult.impressions
+					newResult.maxImpressions
 				)
-				newResult.maxEarnings = Math.max(current.earnings, newResult.earnings)
+				newResult.maxEarnings = Math.max(
+					current.earnings,
+					newResult.maxEarnings
+				)
 				return newResult
 			},
 			{ maxClicks: 0, maxImpressions: 0, maxEarnings: 0 }


### PR DESCRIPTION
- fixing max value of filter campaign stats breakdown filter
- fix filter logic remove everything that is not a number or decimal
- added missing translations