### PR TITLE
Analytics update

### DIFF
--- a/src/actions/accountActions.js
+++ b/src/actions/accountActions.js
@@ -137,7 +137,7 @@ export function updateAccountStats() {
 			const outstandingBalanceMainToken = await getOutstandingBalance({
 				wallet,
 				address,
-				withBalance,
+				withBalance: withBalance.eligible,
 			}).catch(err => {
 				console.error('ERR_OUTSTANDING_BALANCES', err)
 			})

--- a/src/actions/analyticsActions.js
+++ b/src/actions/analyticsActions.js
@@ -75,6 +75,7 @@ function aggrByChannelsSegments({
 	return Object.values(
 		// NOTE: No need to sort them again because fillEmptyTime
 		// is sorting by time after adding the empty time values
+		// TODO: Do not check `minPlatform` for Expired channels
 		aggr
 			.sort((a, b) => b.time - a.time)
 			.reduce(
@@ -97,11 +98,16 @@ function aggrByChannelsSegments({
 
 					current.aggr.push({ value, time })
 
-					const currentAggr = aggregations[time] || { time }
+					const currentAggr = aggregations[time] || {
+						time,
+						value: bigNumberify(0),
+					}
 					const currentChannelValue = bigNumberify(current.value || 0).add(
 						value
 					)
-					const currentTimeValue = bigNumberify(currentAggr.value || 0)
+					const currentTimeValue = currentAggr.value
+
+					current.value = currentChannelValue
 
 					if (
 						currentChannelValue.gt(bigNumberify(minPlatform)) &&
@@ -137,8 +143,6 @@ function aggrByChannelsSegments({
 					) {
 						currentAggr.value = value.add(currentTimeValue)
 					}
-
-					current.value = currentChannelValue
 
 					channels[channelId] = current
 					aggregations[time] = currentAggr

--- a/src/components/dashboard/dashboard/Dashboard.js
+++ b/src/components/dashboard/dashboard/Dashboard.js
@@ -107,13 +107,19 @@ function Dashboard(props) {
 	})
 
 	useEffect(() => {
-		execute(updateSlotsDemandThrottled())
-		execute(updateNav('side', side))
-		execute(getAllItems())
-		analyticsLoop.start()
-		analyticsCampaignsLoop.start()
-		campaignsLoop.start()
-		statsLoop.start()
+		async function updateInitialData() {
+			execute(updateSlotsDemandThrottled())
+			execute(updateNav('side', side))
+			execute(getAllItems())
+			analyticsLoop.start()
+			statsLoop.start()
+			//NOTE: await fo campaign analytics first
+			// because of the campaigns table data update fix
+			await analyticsCampaignsLoop.start()
+			campaignsLoop.start()
+		}
+
+		updateInitialData()
 
 		return () => {
 			analyticsLoop.stop()

--- a/src/reducers/channelsReducer.js
+++ b/src/reducers/channelsReducer.js
@@ -9,7 +9,7 @@ export default function channelsReducer(state = initialState.channels, action) {
 
 	switch (action.type) {
 		case UPDATE_CHANNELS_WITH_BALANCE:
-			newState.withBalance = [...action.withBalance]
+			newState.withBalance = { ...action.withBalance }
 			return newState
 		case RESET_CHANNELS_WITH_BALANCE:
 			newState.withBalance = initialState.channels.withBalance

--- a/src/selectors/accountSelectors.js
+++ b/src/selectors/accountSelectors.js
@@ -77,7 +77,17 @@ export const selectAccountIdentityRoutineAuthTuple = createSelector(
 
 export const selectChannelsWithUserBalances = createSelector(
 	selectChannels,
-	({ withBalance }) => withBalance || []
+	({ withBalance }) => withBalance || {}
+)
+
+export const selectChannelsWithUserBalancesEligible = createSelector(
+	selectChannelsWithUserBalances,
+	({ eligible }) => eligible || []
+)
+
+export const selectChannelsWithUserBalancesAll = createSelector(
+	selectChannelsWithUserBalances,
+	({ all }) => all || {}
 )
 
 export const selectAccountIdentityCurrentPrivileges = createSelector(

--- a/src/selectors/analyticsSelectors.js
+++ b/src/selectors/analyticsSelectors.js
@@ -35,6 +35,15 @@ export const selectCampaignAnalyticsByChannelStats = createSelector(
 		(analyticsByType.byChannelStats || {})[campaignId] || {}
 )
 
+export const selectCampaignAnalyticsByChannelToAdUnit = createSelector(
+	(state, { type, campaignId } = {}) => [
+		selectCampaignAnalyticsByChannelStats(state, { type, campaignId }),
+	],
+	([{ reportChannelToAdUnit }]) => {
+		return reportChannelToAdUnit || {}
+	}
+)
+
 export const selectAnalyticsDataAggr = createSelector(
 	[selectAnalytics, (_, opts = {}) => opts],
 	(analytics = {}, { side, eventType, metric, timeframe }) => {

--- a/src/selectors/tablesDataSelectors.js
+++ b/src/selectors/tablesDataSelectors.js
@@ -11,12 +11,12 @@ import {
 import { formatUnits } from 'ethers/utils'
 
 function selectCampaignEventsCount(type, campaignId) {
-	Object.values(
+	return Object.values(
 		selectCampaignAnalyticsByChannelToAdUnit(null, {
 			type,
 			campaignId,
 		})
-	).reduce((a, b) => a + b)
+	).reduce((a, b) => a + b, 0)
 }
 
 export const selectCampaignsTableData = createSelector(
@@ -36,8 +36,8 @@ export const selectCampaignsTableData = createSelector(
 				},
 				depositAmount: Number(formatUnits(item.depositAmount || '0', decimals)),
 				fundsDistributedRatio: item.status.fundsDistributedRatio || 0,
-				impressions: selectCampaignEventsCount('IMPRESSION, item.id'),
-				clicks: selectCampaignEventsCount('CLICK, item.id'),
+				impressions: selectCampaignEventsCount('IMPRESSION', item.id),
+				clicks: selectCampaignEventsCount('CLICK', item.id),
 				minPerImpression:
 					Number(
 						formatUnits(

--- a/src/selectors/tablesDataSelectors.js
+++ b/src/selectors/tablesDataSelectors.js
@@ -6,8 +6,18 @@ import {
 	selectAdUnits,
 	creatArrayOnlyLengthChangeSelector,
 	selectCampaignAnalyticsByChannelStats,
+	selectCampaignAnalyticsByChannelToAdUnit,
 } from 'selectors'
 import { formatUnits } from 'ethers/utils'
+
+function selectCampaignEventsCount(type, campaignId) {
+	Object.values(
+		selectCampaignAnalyticsByChannelToAdUnit(null, {
+			type,
+			campaignId,
+		})
+	).reduce((a, b) => a + b)
+}
 
 export const selectCampaignsTableData = createSelector(
 	[selectCampaignsArray, selectRoutineWithdrawTokens, (_, side) => side],
@@ -26,8 +36,8 @@ export const selectCampaignsTableData = createSelector(
 				},
 				depositAmount: Number(formatUnits(item.depositAmount || '0', decimals)),
 				fundsDistributedRatio: item.status.fundsDistributedRatio || 0,
-				impressions: Number(item.impressions || '0'),
-				clicks: Number(item.clicks || '0'),
+				impressions: selectCampaignEventsCount('IMPRESSION, item.id'),
+				clicks: selectCampaignEventsCount('CLICK, item.id'),
 				minPerImpression:
 					Number(
 						formatUnits(

--- a/src/services/adex-market/actions.js
+++ b/src/services/adex-market/actions.js
@@ -174,10 +174,11 @@ export const closeCampaignMarket = ({ campaign, authSig }) => {
 		.then(processResponse)
 }
 
-export const getAllCampaigns = ({ all, statuses } = {}) => {
+export const getAllCampaigns = ({ all, statuses, byEarner } = {}) => {
 	const queryParams = {
 		...(all && { all: true }),
 		...(statuses && { status: statuses.join(',') }),
+		byEarner,
 	}
 
 	return requester

--- a/src/services/adex-market/actions.js
+++ b/src/services/adex-market/actions.js
@@ -154,10 +154,6 @@ export const getCampaigns = ({ authSig, creator }) => {
 			route: 'campaigns/by-owner',
 			method: 'GET',
 			noCache: true,
-			queryParams: {
-				byCreator: creator, //
-				t: Date.now(),
-			},
 			authSig,
 		})
 		.then(processResponse)

--- a/src/services/adex-validator/actions.js
+++ b/src/services/adex-validator/actions.js
@@ -121,8 +121,6 @@ export const closeCampaign = ({ campaign, account }) => {
 }
 
 export const identityAnalytics = async ({
-	idenityAddr,
-	campaign,
 	campaignId,
 	leaderAuth,
 	eventType,
@@ -130,6 +128,7 @@ export const identityAnalytics = async ({
 	timeframe,
 	limit,
 	side,
+	segmentByChannel,
 }) => {
 	const baseUrl = VALIDATOR_LEADER_URL
 	const requester = getValidatorRequester({ baseUrl })
@@ -138,14 +137,14 @@ export const identityAnalytics = async ({
 		.fetch({
 			route: `/analytics/for-${side}${campaignId || ''}`,
 			method: 'GET',
-			queryParams: { eventType, metric, timeframe, limit },
+			queryParams: { eventType, metric, timeframe, limit, segmentByChannel },
 			headers: {
 				authorization: BEARER_PREFIX + leaderAuth,
 			},
 		})
 		.then(processResponse)
 
-	return aggregates
+	return { aggregates, metric }
 }
 
 export const identityCampaignsAnalytics = async ({ leaderAuth, eventType }) => {

--- a/src/services/smart-contracts/actions/core.js
+++ b/src/services/smart-contracts/actions/core.js
@@ -93,8 +93,8 @@ function getReadyCampaign(campaign, identity, mainToken) {
 	const validators = newCampaign.validators.map(v => {
 		const deposit = bigNumberify(newCampaign.depositAmount || 0)
 		const fee = deposit
+			.mul(bigNumberify(v.feeNum || 1))
 			.div(bigNumberify(v.feeDen || 1))
-			.mul(bigNumberify(v.feeNum || 0))
 			.toString()
 
 		const validator = {
@@ -238,18 +238,26 @@ export async function getChannelsWithOutstanding({ identityAddr, wallet }) {
 			})
 	)
 
-	const all = {
+	const all = Object.assign(
+		{},
 		...allChannels.map(c => {
 			const { channel } = c
-			const { id, depositAmount } = channel
+			const { id, depositAmount, depositAsset } = channel
 			const balanceNum = bigNumberify(depositAmount)
 				.sub(bigNumberify(c.channel.spec.validators[0].fee))
 				.sub(bigNumberify(c.channel.spec.validators[1].fee))
 				.toString()
 
-			return { [c.channel.id.toLowerCase()]: { id, depositAmount, balanceNum } }
-		}),
-	}
+			return {
+				[c.channel.id.toLowerCase()]: {
+					id,
+					depositAmount,
+					depositAsset,
+					balanceNum,
+				},
+			}
+		})
+	)
 
 	const eligible = allChannels.filter(x => {
 		return (

--- a/src/services/smart-contracts/actions/core.js
+++ b/src/services/smart-contracts/actions/core.js
@@ -1,10 +1,5 @@
 import crypto from 'crypto'
-import {
-	Channel,
-	splitSig,
-	ChannelState,
-	RoutineOps,
-} from 'adex-protocol-eth/js'
+import { Channel, splitSig, RoutineOps } from 'adex-protocol-eth/js'
 import BalanceTree from 'adex-protocol-eth/js/BalanceTree'
 import { getEthers } from 'services/smart-contracts/ethers'
 import {
@@ -33,7 +28,7 @@ import {
 } from 'selectors'
 import { formatTokenAmount } from 'helpers/formatters'
 import IdentityABI from 'adex-protocol-eth/abi/Identity'
-import { selectChannelsWithUserBalances } from 'selectors'
+import { selectChannelsWithUserBalancesEligible } from 'selectors'
 
 const { AdExCore } = contracts
 const Core = new Interface(AdExCore.abi)
@@ -42,14 +37,14 @@ const IdentityInterface = new Interface(IdentityABI)
 const timeframe = 15 * 1000 // 1 event per 15 seconds
 const VALID_UNTIL_COEFFICIENT = 0.5
 const VALID_UNTIL_MIN_PERIOD = 15 * 24 * 60 * 60 * 1000 // 15 days in ms
-const OUTSTANDING_STATUSES = [
-	'Active',
-	'Ready',
-	'Exhausted',
-	'Offline',
-	'Unhealthy',
-	'Withdraw',
-]
+const OUTSTANDING_STATUSES = {
+	Active: true,
+	Ready: true,
+	Exhausted: true,
+	Offline: true,
+	Unhealthy: true,
+	Withdraw: true,
+}
 
 const EXTRA_PROCESS_TIME = 69 * 60 // 69 min in seconds
 
@@ -162,12 +157,12 @@ const getWithdrawnPerUserOutstanding = async ({
 
 export async function getChannelsWithOutstanding({ identityAddr, wallet }) {
 	const { authType } = wallet
-	const channels = await getAllCampaigns({ statuses: OUTSTANDING_STATUSES })
+	const channels = await getAllCampaigns({ all: true, byEarner: identityAddr })
 	const { AdExCore } = await getEthers(authType)
 	const feeTokenWhitelist = selectFeeTokenWhitelist()
 	const routineWithdrawTokens = selectRoutineWithdrawTokens()
 
-	const all = await Promise.all(
+	const allChannels = await Promise.all(
 		channels
 			.filter(
 				channel =>
@@ -175,9 +170,7 @@ export async function getChannelsWithOutstanding({ identityAddr, wallet }) {
 					channel.status &&
 					channel.status.lastApprovedBalances &&
 					channel.status.lastApprovedSigs &&
-					routineWithdrawTokens[channel.depositAsset] &&
-					new Date((channel.validUntil - EXTRA_PROCESS_TIME) * 1000) >
-						Date.now()
+					routineWithdrawTokens[channel.depositAsset]
 			)
 			.map(channel => {
 				const { lastApprovedBalances } = channel.status
@@ -228,6 +221,10 @@ export async function getChannelsWithOutstanding({ identityAddr, wallet }) {
 					bigNumberify(feeTokenWhitelist[channel.depositAsset].min)
 				)
 
+				const balanceNum = bigNumberify(channel.depositAmount)
+					.sub(bigNumberify(channel.spec.validators[0].fee || 0))
+					.sub(bigNumberify(channel.spec.validators[1].fee || 0))
+
 				return {
 					channel,
 					balance,
@@ -236,19 +233,37 @@ export async function getChannelsWithOutstanding({ identityAddr, wallet }) {
 					outstandingAvailable,
 					// mTree,
 					bTree,
+					balanceNum,
 				}
 			})
 	)
 
-	const eligible = all.filter(x => {
+	const all = {
+		...allChannels.map(c => {
+			const { channel } = c
+			const { id, depositAmount } = channel
+			const balanceNum = bigNumberify(depositAmount)
+				.sub(bigNumberify(c.channel.spec.validators[0].fee))
+				.sub(bigNumberify(c.channel.spec.validators[1].fee))
+				.toString()
+
+			return { [c.channel.id.toLowerCase()]: { id, depositAmount, balanceNum } }
+		}),
+	}
+
+	const eligible = allChannels.filter(x => {
 		return (
+			OUTSTANDING_STATUSES[x.channel.status.name] &&
+			new Date((x.channel.validUntil - EXTRA_PROCESS_TIME) * 1000) >
+				Date.now() &&
 			x.outstanding.gt(
 				bigNumberify(routineWithdrawTokens[x.channel.depositAsset].minPlatform)
-			) && x.outstandingAvailable.gt(bigNumberify('0'))
+			) &&
+			x.outstandingAvailable.gt(bigNumberify('0'))
 		)
 	})
 
-	return eligible
+	return { all, eligible }
 }
 
 async function getChannelsToSweepFrom({ amountToSweep, withBalance = [] }) {
@@ -345,7 +360,7 @@ function hasValidExecuteRoutines(routineAuthTuple) {
 export async function getSweepChannelsTxns({ account, amountToSweep }) {
 	const { wallet, identity } = account
 	// TODO: pass withBalance as prop
-	const withBalance = selectChannelsWithUserBalances()
+	const withBalance = selectChannelsWithUserBalancesEligible()
 
 	const { AdExCore } = await getEthers(wallet.authType)
 	const identityAddr = identity.address

--- a/src/services/store-data/analytics.js
+++ b/src/services/store-data/analytics.js
@@ -15,7 +15,7 @@ const analyticsLoop = new Loop({
 
 const analyticsCampaignsLoop = new Loop({
 	timeout: LOOP_TIMEOUT,
-	syncAction: () => execute(updateAccountCampaignsAnalytics()),
+	syncAction: async () => await execute(updateAccountCampaignsAnalytics()),
 	loopName: '_ANALYTICS_CAMPAIGNS_ADVANCED',
 })
 

--- a/src/services/store-data/campaigns.js
+++ b/src/services/store-data/campaigns.js
@@ -6,12 +6,8 @@ import { MOON_GRAVITY_ACCELERATION, MOON_TO_EARTH_WEIGHT } from 'constants/misc'
 const LOOP_TIMEOUT =
 	(69 - Math.floor(MOON_GRAVITY_ACCELERATION / MOON_TO_EARTH_WEIGHT)) * 500
 
-let updates = 0
 const syncCampaigns = () => {
-	//TEMP
-	const updateStats = updates % 3 === 0
-	updates++
-	execute(updateUserCampaigns(updateStats))
+	execute(updateUserCampaigns())
 }
 
 const campaignsLoop = new Loop({

--- a/src/services/store-data/loop.js
+++ b/src/services/store-data/loop.js
@@ -40,9 +40,9 @@ export default class Looper {
 		this.loopTimeout = setTimeout(this.startLoop, this.timeout)
 	}
 
-	start = () => {
+	start = async () => {
 		this.clearLoopTimeout()
-		this.startLoop()
+		await this.startLoop()
 	}
 
 	stop = () => {


### PR DESCRIPTION
* sync outstanding with analytics `eventsPayouts` (closes #317) - may need more more "fine tuning" 
* safe calculation of validator fees
* use advanced analytics for channels clicks and impressions (closes #335)
* make data loop start method `async`
* get all and active campaigns with outstanding balance at once - `eligible` - used for calculating  `outstandingBalance` and `all` - used for analytics (saved with only few props that are needed for the analytics )