### PR TITLE
Campaigns valid until update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3210,8 +3210,8 @@
       }
     },
     "adex-translations": {
-      "version": "git+https://git@github.com/AdExNetwork/adex-translations.git#7eaf03617e0cb8b3081c28e21d907d75ad4212d2",
-      "from": "git+https://git@github.com/AdExNetwork/adex-translations.git#7eaf03617e0cb8b3081c28e21d907d75ad4212d2"
+      "version": "git+https://git@github.com/AdExNetwork/adex-translations.git#089c1e7f77d4c3564a1308b37ad03ae540408af5",
+      "from": "git+https://git@github.com/AdExNetwork/adex-translations.git#089c1e7f77d4c3564a1308b37ad03ae540408af5"
     },
     "aes-js": {
       "version": "3.0.0",
@@ -4561,7 +4561,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -5940,7 +5941,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "normalize-path": {
           "version": "3.0.0",
@@ -6939,7 +6941,8 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -8052,7 +8055,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -16082,7 +16086,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "node-releases": {
           "version": "1.1.26",
@@ -17973,7 +17978,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "adex-constants": "1.0.10",
     "adex-models": "git+https://git@github.com/AdExBlockchain/adex-models.git#499114f10e52f06fe59199b187c7a9a79173a12e",
     "adex-protocol-eth": "4.2.4",
-    "adex-translations": "git+https://git@github.com/AdExNetwork/adex-translations.git#7eaf03617e0cb8b3081c28e21d907d75ad4212d2",
+    "adex-translations": "git+https://git@github.com/AdExNetwork/adex-translations.git#089c1e7f77d4c3564a1308b37ad03ae540408af5",
     "base64url": "^3.0.1",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "chart.js": "^2.7.2",

--- a/src/actions/campaignActions.js
+++ b/src/actions/campaignActions.js
@@ -848,7 +848,6 @@ export function validateNewCampaignFinance({
 				title,
 				activeFrom,
 				withdrawPeriodStart,
-				created,
 				// pricingBounds,
 				pricingBoundsCPMUserInput,
 				audienceInput,
@@ -891,7 +890,7 @@ export function validateNewCampaignFinance({
 					activeFrom,
 					withdrawPeriodStart,
 					dirty,
-					created,
+					created: Date.now(),
 				})(dispatch),
 			])
 

--- a/src/actions/validationActions.js
+++ b/src/actions/validationActions.js
@@ -15,6 +15,10 @@ import {
 import { getErrorMsg } from 'helpers/errors'
 import { getEmail } from 'services/adex-relayer/actions'
 import { formatTokenAmount } from 'helpers/formatters'
+import {
+	MAX_CAMPAIGN_WITHDRAW_START_DAYS,
+	MAX_CAMPAIGN_WITHDRAW_START,
+} from 'constants/targeting'
 const { IdentityPrivilegeLevel, CountryTiers, OsGroups } = constants
 const { bondPerActionToUserInputPerMileValue } = helpers
 
@@ -591,13 +595,20 @@ const getCampaignDatesValidation = ({
 	} else if (withdrawPeriodStart && withdrawPeriodStart < created) {
 		errWithdrawPeriodStart = { message: 'ERR_END_BEFORE_NOW' }
 	} else if (activeFrom && activeFrom < created) {
-		errWithdrawPeriodStart = { message: 'ERR_START_BEFORE_NOW' }
+		errActiveFrom = { message: 'ERR_START_BEFORE_NOW' }
 	} else if (activeFrom && !withdrawPeriodStart) {
 		errWithdrawPeriodStart = { message: 'ERR_NO_END' }
 	}
 
 	if (!withdrawPeriodStart) {
 		errWithdrawPeriodStart = { message: 'ERR_NO_DATE_SET' }
+	}
+
+	if (withdrawPeriodStart > created + MAX_CAMPAIGN_WITHDRAW_START) {
+		errWithdrawPeriodStart = {
+			message: 'ERR_CAMPAIGN_END_DATE_OVER_MAX',
+			args: [MAX_CAMPAIGN_WITHDRAW_START_DAYS],
+		}
 	}
 
 	if (!activeFrom) {

--- a/src/components/dashboard/forms/items/Campaign/CampaignFinance.js
+++ b/src/components/dashboard/forms/items/Campaign/CampaignFinance.js
@@ -27,6 +27,12 @@ import {
 import { execute, updateNewCampaign, validateNumberString } from 'actions'
 import { GETTING_CAMPAIGNS_FEES } from 'constants/spinners'
 import { validations } from 'adex-models'
+import { DEFAULT_DATETIME_FORMAT } from 'helpers/formatters'
+import {
+	MAX_CAMPAIGN_WITHDRAW_START,
+	MAX_CAMPAIGN_WITHDRAW_START_DAYS,
+	DAY,
+} from 'constants/targeting'
 const { isNumberString } = validations
 
 const moment = new MomentUtils()
@@ -259,7 +265,7 @@ function CampaignFinance({ validateId, ...rest }) {
 							fullWidth
 							calendarIcon
 							label={t('CAMPAIGN_STARTS')}
-							minDate={now}
+							minDate={now + 3 * 60 * 60 * 1000}
 							maxDate={to}
 							onChange={val => {
 								execute(updateNewCampaign('activeFrom', val.valueOf()))
@@ -271,6 +277,7 @@ function CampaignFinance({ validateId, ...rest }) {
 									? errFrom.errMsg
 									: t('CAMPAIGN_STARTS_FROM_HELPER_TXT')
 							}
+							format={DEFAULT_DATETIME_FORMAT}
 						/>
 					</Grid>
 					<Grid item xs={12} sm={12} md={6}>
@@ -282,6 +289,7 @@ function CampaignFinance({ validateId, ...rest }) {
 							calendarIcon
 							label={t('CAMPAIGN_ENDS')}
 							minDate={from || now}
+							maxDate={now + MAX_CAMPAIGN_WITHDRAW_START - DAY}
 							onChange={val =>
 								execute(updateNewCampaign('withdrawPeriodStart', val.valueOf()))
 							}
@@ -290,8 +298,11 @@ function CampaignFinance({ validateId, ...rest }) {
 							helperText={
 								errTo && !!errTo.dirty
 									? errTo.errMsg
-									: t('CAMPAIGN_ENDS_HELPER_TXT')
+									: t('CAMPAIGN_ENDS_HELPER_TXT', {
+											args: [MAX_CAMPAIGN_WITHDRAW_START_DAYS],
+									  })
 							}
+							format={DEFAULT_DATETIME_FORMAT}
 						/>
 					</Grid>
 					<Grid item xs={12} sm={12} md={6}>

--- a/src/constants/targeting.js
+++ b/src/constants/targeting.js
@@ -38,3 +38,9 @@ export const SOURCES = {
 	tags: { src: AcTags, collection: 'targeting' },
 	custom: { src: [], collection: 'targeting' },
 }
+
+export const HOUR = 60 * 60 * 1000
+export const DAY = 24 * HOUR
+export const MAX_CAMPAIGN_WITHDRAW_START_DAYS = 90
+export const MAX_CAMPAIGN_WITHDRAW_START =
+	DAY * MAX_CAMPAIGN_WITHDRAW_START_DAYS

--- a/src/services/translations/translations.js
+++ b/src/services/translations/translations.js
@@ -49,16 +49,20 @@ export const translate = (
 
 	let translation = removeTags(translations[language][key] || val)
 
-	if (args.length && Array.isArray(args)) {
-		const translatedArgs = args.map(a => {
-			if (typeof a === 'string') {
-				return translations[language][a] || a
-			} else {
-				return a
-			}
-		})
+	if (Array.isArray(args)) {
+		if (args.length) {
+			const translatedArgs = args.map(a => {
+				if (typeof a === 'string') {
+					return translations[language][a] || a
+				} else {
+					return a
+				}
+			})
 
-		translation = interpolate(translation, translatedArgs)
+			translation = interpolate(translation, translatedArgs)
+		} else {
+			translation = translation.replace(/\${(\w+)}/, ' ')
+		}
 	}
 
 	return translation


### PR DESCRIPTION
- updated campaigns `validUntil` - 360 days from creation
- added 90 day limit to campaign end (`withdrawPeriodStart`)
- fixed and updated validation of campaign dates
- updated translations interpolation
