### PR TITLE
Table select all

### DIFF
--- a/src/components/dashboard/containers/Tables/AdSlotsTable.js
+++ b/src/components/dashboard/containers/Tables/AdSlotsTable.js
@@ -138,19 +138,6 @@ const getCols = ({ symbol }) => [
 	},
 ]
 
-const onDownload = (buildHead, buildBody, columns, data) => {
-	const mappedData = data.map(i => ({
-		index: i.index,
-		data: [
-			i.data[0].id,
-			i.data[1],
-			i.data[2].replace('legacy_', ''),
-			formatDateTime(i.data[3]),
-		],
-	}))
-	return `${buildHead(columns)}${buildBody(mappedData)}`.trim()
-}
-
 const getOptions = () => ({
 	filterType: 'multiselect',
 	sortOrder: {
@@ -158,8 +145,6 @@ const getOptions = () => ({
 		direction: 'desc',
 	},
 	selectableRows: 'none',
-	onDownload: (buildHead, buildBody, columns, data) =>
-		onDownload(buildHead, buildBody, columns, data),
 })
 
 function AdSlotsTable(props) {

--- a/src/components/dashboard/containers/Tables/AdUnitsTable.js
+++ b/src/components/dashboard/containers/Tables/AdUnitsTable.js
@@ -166,27 +166,12 @@ const getCols = ({ noActions, noClone, maxImpressions, maxClicks, maxCTR }) => [
 	},
 ]
 
-const onDownload = (buildHead, buildBody, columns, data) => {
-	const mappedData = data.map(i => ({
-		index: i.index,
-		data: [
-			i.data[0].id,
-			i.data[1],
-			i.data[2].replace('legacy_', ''),
-			formatDateTime(i.data[3]),
-		],
-	}))
-	return `${buildHead(columns)}${buildBody(mappedData)}`.trim()
-}
-
 const getOptions = () => ({
 	filterType: 'multiselect',
 	sortOrder: {
 		name: 'created',
 		direction: 'desc',
 	},
-	onDownload: (buildHead, buildBody, columns, data) =>
-		onDownload(buildHead, buildBody, columns, data),
 })
 
 function AdUnitsTable(props) {

--- a/src/components/dashboard/containers/Tables/BestEarnersTable.js
+++ b/src/components/dashboard/containers/Tables/BestEarnersTable.js
@@ -85,22 +85,12 @@ const getCols = ({ symbol }) => [
 	},
 ]
 
-const onDownload = (buildHead, buildBody, columns, data) => {
-	const mappedData = data.map(i => ({
-		index: i.index,
-		data: [i.data[0].id, i.data[1].replace('legacy_', ''), i.data[2]],
-	}))
-	return `${buildHead(columns)}${buildBody(mappedData)}`.trim()
-}
-
 const getOptions = () => ({
 	filterType: 'multiselect',
 	sortOrder: {
 		name: 'ctr',
 		direction: 'desc',
 	},
-	onDownload: (buildHead, buildBody, columns, data) =>
-		onDownload(buildHead, buildBody, columns, data),
 	rowsPerPage: 5,
 })
 

--- a/src/components/dashboard/containers/Tables/CampaignsTable.js
+++ b/src/components/dashboard/containers/Tables/CampaignsTable.js
@@ -273,27 +273,6 @@ const getCols = ({ symbol, maxImpressions, maxDeposit, maxClicks }) => [
 	},
 ]
 
-const onDownload = (buildHead, buildBody, columns, data, decimals, symbol) => {
-	const mappedData = data.map(i => ({
-		index: i.index,
-		data: [
-			i.data[0],
-			i.data[1],
-			i.data[2],
-			i.data[3].humanFriendlyName,
-			`${i.data[4]} ${symbol}`,
-			`${((i.data[5] || 0) / 10).toFixed(2)} %`,
-			i.data[6],
-			i.data[7],
-			i.data[8],
-			formatDateTime(i.data[9]),
-			formatDateTime(i.data[10]),
-			formatDateTime(i.data[11]),
-		],
-	}))
-	return `${buildHead(columns)}${buildBody(mappedData)}`.trim()
-}
-
 const getOptions = ({ decimals, symbol }) => ({
 	filterType: 'multiselect',
 	selectableRows: 'none',
@@ -301,8 +280,6 @@ const getOptions = ({ decimals, symbol }) => ({
 		name: 'created',
 		direction: 'desc',
 	},
-	onDownload: (buildHead, buildBody, columns, data) =>
-		onDownload(buildHead, buildBody, columns, data, decimals, symbol),
 	customToolbarSelect: (selectedRows, displayData, _setSelectedRows) => {
 		const selectedIndexes = selectedRows.data.map(i => i.dataIndex)
 		const selectedItems = displayData

--- a/src/components/dashboard/containers/Tables/MUIDataTableEnhanced.js
+++ b/src/components/dashboard/containers/Tables/MUIDataTableEnhanced.js
@@ -14,6 +14,7 @@ import {
 } from 'actions'
 import { makeStyles } from '@material-ui/core/styles'
 import { useSelector } from 'react-redux'
+import CustomTableViewCol from './custom/CustomTableViewCol'
 
 const generalTableOptions = {
 	rowsPerPage: 5,
@@ -132,6 +133,22 @@ function MUIDataTableEnhanced(props) {
 				title={title}
 				data={data}
 				columns={columnsWithFilters}
+				components={{
+					TableViewCol: props => (
+						<CustomTableViewCol
+							{...props}
+							// override updateColumns
+							updateColumns={newViewColumns => {
+								execute(
+									updateTableState(tableId, {
+										...tableState,
+										viewColumnsState: newViewColumns,
+									})
+								)
+							}}
+						/>
+					),
+				}}
 				options={{
 					...generalTableOptions,
 					...options,
@@ -154,6 +171,7 @@ function MUIDataTableEnhanced(props) {
 								'propsUpdate',
 								'filterChange',
 								'rowSelectionChange',
+								'viewColumnsChange',
 							].includes(action)
 						) {
 							execute(

--- a/src/components/dashboard/containers/Tables/custom/CustomTableViewCol.js
+++ b/src/components/dashboard/containers/Tables/custom/CustomTableViewCol.js
@@ -1,0 +1,153 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Checkbox from '@material-ui/core/Checkbox'
+import Typography from '@material-ui/core/Typography'
+import FormControl from '@material-ui/core/FormControl'
+import FormGroup from '@material-ui/core/FormGroup'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import { makeStyles } from '@material-ui/core/styles'
+import { Divider } from '@material-ui/core'
+
+// Extracted from
+// https://github.com/gregnb/mui-datatables/blob/bb0cf931decae7e5bec49a6b5f3343408bc4c0b5/src/components/TableViewCol.js
+
+const useStyles = makeStyles(
+	theme => ({
+		root: {
+			padding: '16px 24px 16px 24px',
+			fontFamily: 'Roboto',
+		},
+		title: {
+			marginLeft: '-7px',
+			marginRight: '24px',
+			fontSize: '14px',
+			color: theme.palette.text.secondary,
+			textAlign: 'left',
+			fontWeight: 500,
+		},
+		formGroup: {
+			marginTop: '8px',
+		},
+		formControl: {},
+		checkbox: {
+			padding: '0px',
+			width: '32px',
+			height: '32px',
+		},
+		checkboxRoot: {},
+		checked: {},
+		label: {
+			fontSize: '15px',
+			marginLeft: '8px',
+			color: theme.palette.text.primary,
+		},
+	}),
+	{ name: 'MUIDataTableViewCol' }
+)
+
+const CustomTableViewCol = ({
+	columns,
+	options,
+	components = {},
+	onColumnUpdate,
+	updateColumns,
+}) => {
+	const classes = useStyles()
+	const textLabels = options.textLabels.viewColumns
+	const CheckboxComponent = components.Checkbox || Checkbox
+
+	const handleColChange = index => {
+		onColumnUpdate(index)
+	}
+
+	const toggleAllColumns = () => {
+		const newColumns = {}
+		const atLeastOneUnchecked = columns.some(e => e.display === 'false')
+		columns.forEach(c => {
+			newColumns[c.name] = atLeastOneUnchecked ? true : false
+		})
+		updateColumns(newColumns)
+	}
+
+	return (
+		<FormControl
+			component={'fieldset'}
+			className={classes.root}
+			aria-label={textLabels.titleAria}
+		>
+			<Typography variant='caption' className={classes.title}>
+				{textLabels.title}
+			</Typography>
+			<FormGroup className={classes.formGroup}>
+				<FormControlLabel
+					classes={{
+						root: classes.formControl,
+						label: classes.label,
+					}}
+					control={
+						<CheckboxComponent
+							color='primary'
+							data-description='table-view-col'
+							className={classes.checkbox}
+							classes={{
+								root: classes.checkboxRoot,
+								checked: classes.checked,
+							}}
+							indeterminate={
+								columns.some(e => e.display === 'true') &&
+								!columns.every(e => e.display === 'true')
+							}
+							onChange={() => toggleAllColumns()}
+							checked={columns.every(e => e.display === 'true')}
+							value={'select-all'}
+						/>
+					}
+					label={'Select All'}
+				/>
+				<Divider />
+				{columns.map((column, index) => {
+					return (
+						column.display !== 'excluded' &&
+						column.viewColumns !== false && (
+							<FormControlLabel
+								key={index}
+								classes={{
+									root: classes.formControl,
+									label: classes.label,
+								}}
+								control={
+									<CheckboxComponent
+										color='primary'
+										data-description='table-view-col'
+										className={classes.checkbox}
+										classes={{
+											root: classes.checkboxRoot,
+											checked: classes.checked,
+										}}
+										onChange={() => handleColChange(index)}
+										checked={column.display === 'true'}
+										value={column.name}
+									/>
+								}
+								label={column.label}
+							/>
+						)
+					)
+				})}
+			</FormGroup>
+		</FormControl>
+	)
+}
+
+CustomTableViewCol.propTypes = {
+	/** Columns used to describe table */
+	columns: PropTypes.array.isRequired,
+	/** Options used to describe table */
+	options: PropTypes.object.isRequired,
+	/** Callback to trigger View column update */
+	onColumnUpdate: PropTypes.func,
+	/** Extend the style applied to components */
+	classes: PropTypes.object,
+}
+
+export default CustomTableViewCol

--- a/src/components/dashboard/containers/Tables/custom/CustomTableViewCol.js
+++ b/src/components/dashboard/containers/Tables/custom/CustomTableViewCol.js
@@ -60,11 +60,20 @@ const CustomTableViewCol = ({
 		onColumnUpdate(index)
 	}
 
+	const checkIfIndeterminate = () =>
+		columns.some(e => e.display === 'true') && !checkIfAllChecked()
+
+	const checkIfAllChecked = () =>
+		columns
+			.filter(e => e.display !== 'excluded')
+			.every(e => e.display === 'true')
+
 	const toggleAllColumns = () => {
 		const newColumns = {}
 		const atLeastOneUnchecked = columns.some(e => e.display === 'false')
 		columns.forEach(c => {
-			newColumns[c.name] = atLeastOneUnchecked ? true : false
+			if (c.display !== 'excluded')
+				newColumns[c.name] = atLeastOneUnchecked ? true : false
 		})
 		updateColumns(newColumns)
 	}
@@ -93,12 +102,9 @@ const CustomTableViewCol = ({
 								root: classes.checkboxRoot,
 								checked: classes.checked,
 							}}
-							indeterminate={
-								columns.some(e => e.display === 'true') &&
-								!columns.every(e => e.display === 'true')
-							}
+							indeterminate={checkIfIndeterminate()}
 							onChange={() => toggleAllColumns()}
-							checked={columns.every(e => e.display === 'true')}
+							checked={checkIfAllChecked()}
 							value={'select-all'}
 						/>
 					}


### PR DESCRIPTION
- add custom table view columns component with select all option (closes #321)
- delete all custom on download functions since we want unselected columns not to be exported to CSV (closes #323)
since we already use 
```
	downloadOptions: {
		filterOptions: {
			useDisplayedColumnsOnly: true,
			useDisplayedRowsOnly: true,
		},
	},
```
removing the onDownload functions makes the expected behavior in #323